### PR TITLE
feature: Added flag to make a shared object, used inside ov-router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION=0.5
 all: build lib
 
 CXXFLAGS = -Wall -Wno-deprecated-declarations -std=c++11 -pthread	\
--ggdb -fno-finite-math-only
+-ggdb -fno-finite-math-only -fPIC
 
 OSFLAG :=
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
This will create a short overhead for each function call but enables the digital stage platform to use the libov as shared modules.